### PR TITLE
ci: Rework CI to build Sphinx docs and push to GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+## Sphinx: generated HTML
+**/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,20 @@
-sudo: true
-env:
-  global:
+---
+os: linux
+dist: bionic
 
 language: python
-python:
-  - "3.7"
+python: 3.9
+cache: pip
 
-before_script:
-  - sudo pip install -U sphinx
-
-script:
-  - make html
-  - touch docs/html/.nojekyll
-  - touch docs/.nojekyll
-#   - CI=false npm run build
+before_script: pip install -U sphinx
+script: make clean html
 
 deploy:
   - provider: pages
     verbose: true
     github_token: $GITHUB_TOKEN
     edge: true
-    local_dir: ./docs/html/
+    local_dir: ./_build/html/
     keep_history: true
     on:
-      branch: master
-
+      branch: main

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 # Minimal makefile for Sphinx documentation
 #
 
-# You can set these variables from the command line, and also
-# from the environment for the first two.
-SPHINXOPTS    ?=
-SPHINXBUILD   ?= sphinx-build
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SPHINXPROJ    = prokuranepal.github.io
 SOURCEDIR     = source
-BUILDDIR      = docs
+BUILDDIR      = _build
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,1 +1,0 @@
-<meta http-equiv="refresh" content="0; url=./html/index.html" />

--- a/make.bat
+++ b/make.bat
@@ -8,7 +8,8 @@ if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
 set SOURCEDIR=source
-set BUILDDIR=build
+set BUILDDIR=_build
+set SPHINXPROJ=prokuranepal.github.io
 
 if "%1" == "" goto help
 
@@ -25,11 +26,11 @@ if errorlevel 9009 (
 	exit /b 1
 )
 
-%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
 goto end
 
 :help
-%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
 
 :end
 popd

--- a/source/conf.py
+++ b/source/conf.py
@@ -17,8 +17,8 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'Docs'
-copyright = '2020, Prokura Innovations Pvt. Ltd.'
+project = 'prokuranepal.github.io'
+copyright = '2020-2021, Prokura Innovations Pvt. Ltd.'
 author = 'Prokura Innovations Pvt. Ltd.'
 
 
@@ -51,4 +51,3 @@ html_theme = 'alabaster'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 master_doc = 'index'
-


### PR DESCRIPTION
This commit fixes some of the logic for building and pushing automatic
updates to the GitHub Pages site when source content is changed in the
repository. Specific details of note:

* Fix documentation build paths, do not push to `docs/` folder
* Trigger deploy job on new commits added to `main` branch
* Standardized docs project name "prokuranepal.github.io"

This commit alone will not work. It also needs a `$GITHUB_TOKEN` set as
a secret variable from the Travis CI web interface for the deploy step
to work. Without the token, there is no way for Travis to push the
generated HTML to GitHub Pages, because it will not have access.

See also: https://github.com/jwflory/sphinx-docs-opinionated-quickstart